### PR TITLE
Add triage issues workflow

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -1,0 +1,17 @@
+name: Triage issue
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/software-mansion/projects/4
+          github-token: ${{ secrets.SCARB_TRIAGE_GITHUB_TOKEN }}
+


### PR DESCRIPTION
This workflow will assign issues from this repo to scarb project, so we can track them more easily. 