### PR TITLE
Fix messaging on install and update

### DIFF
--- a/starkup.sh
+++ b/starkup.sh
@@ -198,7 +198,6 @@ warn_missing_path_entries() {
   fi
 }
 
-
 add_alias() {
   _shell_config="$1"
   _alias_def="alias starkup=\"curl --proto '=https' --tlsv1.2 -sSf ${SCRIPT_URL} | sh -s --\""


### PR DESCRIPTION
Closes https://github.com/software-mansion/scarb/issues/1953

This fixes some minor issue regarding info communicated on install/update regarding the actions the user must take:
- The script suggested sourcing config file / re-opening terminal on unchanged config
- The script emitted warnings suggesting adding PATH entries that are already present in the PATH
- The script suggested adding ASDF shims to PATH for non-starkup ASDF installation
- The script did not specify why ASDF should be updated when installed not by starkup