### PR TITLE
Fix asdf version detection for v0.17.0+ (fixes #59)

### DIFF
--- a/starkup.sh
+++ b/starkup.sh
@@ -432,7 +432,7 @@ install_vscode_plugin() {
 }
 
 get_asdf_version() {
-  asdf --version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+(-[^[:space:]]+)?$'
+  asdf --version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+(-[^[:space:]]+)?'
 }
 
 # asdf versions < 0.16.0 are legacy


### PR DESCRIPTION
# Fix asdf version detection for v0.17.0+ (fixes #59)

## Problem

The `get_asdf_version()` function in `starkup.sh` uses a regex pattern with a `$` anchor that expects the version number to be at the end of the line:

```bash
asdf --version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+(-[^[:space:]]+)?$'
```

However, asdf v0.17.0 changed its output format to include additional information:

```
asdf version v0.17.0 (revision fc87e22)
```

The extra text `(revision fc87e22)` after the version number causes the regex to fail because of the `$` end-of-line anchor, resulting in an empty string instead of extracting `0.17.0`.

## Root Cause Analysis

1. **Regex failure**: The `$` anchor expects version to be at end of line, but asdf v0.17.0+ includes revision info
2. **Empty version extraction**: `get_asdf_version()` returns empty string instead of `0.17.0`
3. **Incorrect legacy detection**: `is_asdf_legacy()` calls `version_less_than("", "0.16.0")`
4. **Version comparison bug**: Empty string is treated as less than `0.16.0`, so function returns `true`
5. **Wrong command usage**: Script incorrectly treats asdf v0.17.0 as legacy
6. **Command failure**: Uses deprecated `asdf global` instead of modern `asdf set --home`
7. **Error**: `asdf global` doesn't exist in v0.17.0, causing installation failure

## Solution

**Simple fix**: Remove the `$` anchor from the regex pattern to allow matching versions with additional text after them.

### Before
```bash
asdf --version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+(-[^[:space:]]+)?$'
```

### After  
```bash
asdf --version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+(-[^[:space:]]+)?'
```

## Testing

Verified the fix works correctly with various asdf version output formats:

| Input | Expected | Result | Status |
|-------|----------|--------|---------|
| `asdf version v0.17.0 (revision fc87e22)` | `0.17.0` | `0.17.0` | ✅ |
| `v0.16.7` | `0.16.7` | `0.16.7` | ✅ |
| `0.15.9` | `0.15.9` | `0.15.9` | ✅ |
| `asdf v0.17.1-beta` | `0.17.1-beta` | `0.17.1-beta` | ✅ |
| `version 0.14.0` | `0.14.0` | `0.14.0` | ✅ |

### Legacy Detection Test

Confirmed `is_asdf_legacy()` now works correctly:

| asdf Version | Expected Detection | Result | Status |
|--------------|-------------------|---------|---------|
| `asdf version v0.17.0 (revision fc87e22)` | modern | modern | ✅ |
| `v0.16.0` | modern | modern | ✅ |
| `0.15.9` | legacy | legacy | ✅ |
| `0.14.0` | legacy | legacy | ✅ |

## Impact

- ✅ **Fixes issue #59**: asdf v0.17.0+ now correctly detected as modern
- ✅ **Maintains backward compatibility**: Works with older asdf versions  
- ✅ **Uses correct commands**: `asdf set --home` for modern, `asdf global` for legacy
- ✅ **No breaking changes**: Only fixes the version detection logic

## Files Changed

- `starkup.sh`: Line 434 - Updated regex in `get_asdf_version()` function

## Related Issues

Closes #59

## Verification Steps

To verify this fix works:

1. Install asdf v0.17.0+
2. Run starkup installation
3. Confirm it uses `asdf set --home` instead of `asdf global`
4. Installation should complete successfully 