### PR TITLE
Remove odd trigger on changes to the workflow file

### DIFF
--- a/.github/workflows/auto-update-tools.yml
+++ b/.github/workflows/auto-update-tools.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "0 2 * * 1-5" # 2:00 AM UTC, Monday to Friday
   workflow_dispatch: # Allow manual trigger
-  push:
-    paths:
-      - '.github/workflows/auto-update-tools.yml' # Trigger on changes to this workflow for testing
 
 jobs:
   check-and-update-versions:


### PR DESCRIPTION
It caused a PR to be made on merge of changes to workflow file, when it didn't need to be created