### PR TITLE
chore: bump asdf default version to 0.20.0

### DIFF
--- a/starkup.sh
+++ b/starkup.sh
@@ -7,7 +7,7 @@ SCRIPT_VERSION="0.3.11"
 SCRIPT_URL="https://sh.starkup.sh"
 REPO_URL="https://github.com/software-mansion/starkup"
 
-ASDF_DEFAULT_VERSION="0.19.0"
+ASDF_DEFAULT_VERSION="0.20.0"
 ASDF_INSTALL_DOCS="https://asdf-vm.com/guide/getting-started.html"
 ASDF_MIGRATION_DOCS="https://asdf-vm.com/guide/upgrading-to-v0-16.html"
 ASDF_SHIMS="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"


### PR DESCRIPTION
Update `ASDF_DEFAULT_VERSION` from `0.19.0` to `0.20.0`.