### PR TITLE
Bump tools; Prepare release 0.3.14

### DIFF
--- a/starkup.sh
+++ b/starkup.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-SCRIPT_VERSION="0.3.13"
+SCRIPT_VERSION="0.3.14"
 
 SCRIPT_URL="https://sh.starkup.sh"
 REPO_URL="https://github.com/software-mansion/starkup"
@@ -38,7 +38,7 @@ SCARB_UNINSTALL_INSTRUCTIONS="For uninstallation instructions, refer to https://
 GENERAL_UNINSTALL_INSTRUCTIONS="Try removing TOOL binaries from ${LOCAL_BIN}"
 
 # Set of latest mutually compatible tool versions
-SCARB_LATEST_COMPATIBLE_VERSION="2.19.3"
+SCARB_LATEST_COMPATIBLE_VERSION="2.19.4"
 FOUNDRY_LATEST_COMPATIBLE_VERSION="0.62.1"
 COVERAGE_LATEST_COMPATIBLE_VERSION="0.6.1"
 PROFILER_LATEST_COMPATIBLE_VERSION="0.17.0"


### PR DESCRIPTION
This PR updates tool versions and bumps starkup version to `0.3.14` for release.

## Changes
- Scarb: `2.19.3` → [`2.19.4`](https://github.com/software-mansion/scarb/releases/tag/v2.19.4)
- Starkup version: `0.3.13` → `0.3.14`