### PR TITLE
Bump scarb Relase 2.20.1

### DIFF
--- a/starkup.sh
+++ b/starkup.sh
@@ -2,12 +2,12 @@
 
 set -eu
 
-SCRIPT_VERSION="0.3.16"
+SCRIPT_VERSION="0.3.17"
 
 SCRIPT_URL="https://sh.starkup.sh"
 REPO_URL="https://github.com/software-mansion/starkup"
 
-ASDF_DEFAULT_VERSION="0.20.0"
+ASDF_DEFAULT_VERSION="0.20.1"
 ASDF_INSTALL_DOCS="https://asdf-vm.com/guide/getting-started.html"
 ASDF_MIGRATION_DOCS="https://asdf-vm.com/guide/upgrading-to-v0-16.html"
 ASDF_SHIMS="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"


### PR DESCRIPTION
This pull request makes a minor update to the `starkup.sh` script, primarily bumping version numbers to ensure compatibility with the latest tools.

- Version updates:
  * Updated the script version from `0.3.16` to `0.3.17` in `starkup.sh`
  * Updated the default `asdf` version from `0.20.0` to `0.20.1` in `starkup.sh`