### PR TITLE
Bump scarb; Prepare release 2.20.1

### DIFF
--- a/starkup.sh
+++ b/starkup.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-SCRIPT_VERSION="0.3.16"
+SCRIPT_VERSION="0.3.17"
 
 SCRIPT_URL="https://sh.starkup.sh"
 REPO_URL="https://github.com/software-mansion/starkup"
@@ -38,7 +38,7 @@ SCARB_UNINSTALL_INSTRUCTIONS="For uninstallation instructions, refer to https://
 GENERAL_UNINSTALL_INSTRUCTIONS="Try removing TOOL binaries from ${LOCAL_BIN}"
 
 # Set of latest mutually compatible tool versions
-SCARB_LATEST_COMPATIBLE_VERSION="2.20.0"
+SCARB_LATEST_COMPATIBLE_VERSION="2.20.1"
 FOUNDRY_LATEST_COMPATIBLE_VERSION="0.63.0"
 COVERAGE_LATEST_COMPATIBLE_VERSION="0.6.1"
 PROFILER_LATEST_COMPATIBLE_VERSION="0.17.0"


### PR DESCRIPTION
This pull request updates the `starkup.sh` script to ensure compatibility with the latest version of the Scarb tool and increments the script version accordingly.

Version updates:

* Bumped the `SCRIPT_VERSION` variable from `0.3.16` to `0.3.17` in `starkup.sh` to reflect the new release.

Tool compatibility:

* Updated the `SCARB_LATEST_COMPATIBLE_VERSION` to `2.20.1` in `starkup.sh` to support the latest compatible Scarb tool version.